### PR TITLE
circleci-integration: fixed version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 3
+version: 2.1
 jobs:
   build:
     docker:
@@ -41,7 +41,6 @@ orbs:
   sonarcloud: sonarsource/sonarcloud@1.0.1
 
 workflows:
-  version: 2
   build-and-test:
     jobs:
       - build:


### PR DESCRIPTION
Version changed to 2.1 in order to use orbs.